### PR TITLE
updated link to tutorial

### DIFF
--- a/current/runtime/pallets.md
+++ b/current/runtime/pallets.md
@@ -12,7 +12,7 @@ language.
 
 If you are getting started with Substrate runtime development for the first time, we suggest you try
 our introductory tutorial for
-[creating your first Substrate chain](https://substrate.dev/docs/en/next/tutorials/creating-your-first-substrate-chain/).
+[creating your first Substrate chain](/tutorials/create-your-first-substrate-chain).
 
 ## What is a Pallet?
 


### PR DESCRIPTION
found an old link to the dev hub (https://substrate.dev/docs/en/tutorials/creating-your-first-substrate-chain/). updated it for substrate.io